### PR TITLE
Removes codecov badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/patriques82/alphavantage4j.svg?branch=master)](https://travis-ci.org/patriques82/alphavantage4j) [![Maven Central](https://img.shields.io/maven-central/v/io.github.mainstringargs/alpha-vantage-scraper.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.github.mainstringargs%22%20AND%20a:%22alpha-vantage-scraper%22)
-[![license](https://img.shields.io/github/license/patriques82/alphavantage4j.svg)](https://github.com/patriques82/alphavantage4j/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/mainstringargs/alpha-vantage-scraper.svg)](https://github.com/mainstringargs/alpha-vantage-scraper/blob/master/LICENSE)
 
 # Alpha Vantage Scraper
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Build Status](https://travis-ci.org/patriques82/alphavantage4j.svg?branch=master)](https://travis-ci.org/patriques82/alphavantage4j)
-[![codecov](https://codecov.io/gh/patriques82/alphavantage4j/branch/master/graph/badge.svg)](https://codecov.io/gh/patriques82/alphavantage4j)
+[![Build Status](https://travis-ci.org/patriques82/alphavantage4j.svg?branch=master)](https://travis-ci.org/patriques82/alphavantage4j) [![Maven Central](https://img.shields.io/maven-central/v/io.github.mainstringargs/alpha-vantage-scraper.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.github.mainstringargs%22%20AND%20a:%22alpha-vantage-scraper%22)
 [![license](https://img.shields.io/github/license/patriques82/alphavantage4j.svg)](https://github.com/patriques82/alphavantage4j/blob/master/LICENSE)
 
 # Alpha Vantage Scraper


### PR DESCRIPTION
- It was from the previous project. Since JaCoCo is not configured, the code coverage was not being updated.
- Adds Maven Central badge.
- Update LICENSE badge to link to the current repo instead of the previous one from patriques82