### PR TITLE
Fix version number and project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ calls available in their documentation http://www.alphavantage.co/documentation.
     <dependency>
         <groupId>io.github.mainstringargs</groupId>
         <artifactId>alpha-vantage-scraper</artifactId>
-        <version>1.2.0</version>
+        <version>1.4.0</version>
     </dependency>
 ```
 
@@ -26,7 +26,7 @@ calls available in their documentation http://www.alphavantage.co/documentation.
 
 ```groovy
 dependencies {
-	compile "io.github.mainstringargs:alpha-vantage-scraper:1.2.0"
+	compile "io.github.mainstringargs:alpha-vantage-scraper:1.4.0"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         project_name = project.name
-        project_group = 'org.patriques'
+        project_group = 'io.github.mainstringargs'
         project_version = 1.4
     }
     repositories {
@@ -54,7 +54,7 @@ dependencies {
 
 archivesBaseName = 'alpha-vantage-scraper'
 group = 'io.github.mainstringargs'
-version = '1.2.0'
+version = '1.4.0'
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,20 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.github.mainstringargs</groupId>
 	<artifactId>alpha-vantage-scraper</artifactId>
-	<version>1.2.0</version>
+	<version>1.4.0</version>
 	<packaging>jar</packaging>
 
-	<name>alphavantage4j</name>
-	<description>alphavantage4j is a java wrapper obtaining financial data from alphavantage.com</description>
+	<name>alpha-vantage-scraper</name>
+	<description>alpha-vantage-scraper is a java wrapper obtaining financial data from alphavantage.com</description>
 	<url>https://github.com/patriques82/alphavantage4j</url>
 	<inceptionYear>2017</inceptionYear>
 
 	<developers>
 		<developer>
 			<name>Patrik Nygren</name>
+		</developer>
+		<developer>
+			<name>main(String[] args)</name>
 		</developer>
 	</developers>
 


### PR DESCRIPTION
# Versions fixed on build.gradle and pom.xml

- Since there is a 1.3 tag already, version was updated to 1.4.0 (following semantic versioning)
- Fix some references from the previous project
  - Fix group id on build.grade.
  - Fix project name references on pom.xml
  - Adds developer name on pom.xml

Could you please release the 1.4.0 version to Maven Central and let me know? 
I have another project depending on it.